### PR TITLE
README badge bugfix and work on pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,17 @@ ci:
   autofix_commit_msg: "chore(pre-commit): autofix run"
   autoupdate_commit_msg: "chore(pre-commit): autoupdate hooks"
 
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+
 repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v2.3.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        # args: [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
@@ -13,12 +23,6 @@ repos:
       - id: double-quote-string-fixer
       - id: name-tests-test
       - id: requirements-txt-fixer
-  - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v2.3.0
-    hooks:
-      - id: conventional-pre-commit
-        stages: [commit-msg]
-        # args: [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v2.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,6 @@ ci:
   autoupdate_commit_msg: "chore(pre-commit): autoupdate hooks"
 
 repos:
-  - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v2.3.0
-    hooks:
-      - id: conventional-pre-commit
-        stages: [commit-msg]
-        # args: [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
@@ -19,6 +13,12 @@ repos:
       - id: double-quote-string-fixer
       - id: name-tests-test
       - id: requirements-txt-fixer
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v2.3.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        # args: [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v2.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,12 @@ ci:
   autoupdate_commit_msg: "chore(pre-commit): autoupdate hooks"
 
 repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v2.3.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        # args: [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
@@ -44,9 +50,3 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [types-all]
-  - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v2.3.0
-    hooks:
-      - id: conventional-pre-commit
-        stages: [commit-msg]
-        # args: [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]

--- a/README.md
+++ b/README.md
@@ -3,4 +3,5 @@
 ![PyPI](https://img.shields.io/pypi/v/magic-scrape?logo=python&logoColor=%23cccccc)
 [![pdm-managed](https://img.shields.io/badge/pdm-managed-blueviolet)](https://pdm.fming.dev)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/lmmx/magic-scrape/master.svg)](https://results.pre-commit.ci/latest/github/lmmx/magic-scrape/master)
+
 <!-- [![build status](https://github.com/lmmx/magic-scrape/actions/workflows/master.yml/badge.svg)](https://github.com/lmmx/magic-scrape/actions/workflows/master.yml) -->

--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 ![PyPI](https://img.shields.io/pypi/v/magic-scrape?logo=python&logoColor=%23cccccc)
 [![pdm-managed](https://img.shields.io/badge/pdm-managed-blueviolet)](https://pdm.fming.dev)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/lmmx/magic-scrape/main.svg)](https://results.pre-commit.ci/latest/github/lmmx/magic-scrape/main)
-<!-- [![build status](https://github.com/lmmx/magic-scrape/actions/workflows/main.yml/badge.svg)](https://github.com/lmmx/magic-scrape/actions/workflows/main.yml) -->
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/lmmx/magic-scrape/master.svg)](https://results.pre-commit.ci/latest/github/lmmx/magic-scrape/master)
+<!-- [![build status](https://github.com/lmmx/magic-scrape/actions/workflows/master.yml/badge.svg)](https://github.com/lmmx/magic-scrape/actions/workflows/master.yml) -->


### PR DESCRIPTION
- fix: correct branch name in pre-commit README badge
- chore: conventional commit at head of pre-commit hooks (for ease of reference to category names and so it runs first and is shown as the first check result)