### PR TITLE
main return model

### DIFF
--- a/src/magic_scrape/cli.py
+++ b/src/magic_scrape/cli.py
@@ -8,7 +8,15 @@ import defopt
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from pydantic_settings import BaseSettings
 
-__all__ = ["OpenAI", "APIConfig", "ScraperConfig", "CLIConfig", "cli_context", "main"]
+__all__ = [
+    "OpenAI",
+    "APIConfig",
+    "ScraperConfig",
+    "CLIConfig",
+    "cli_context",
+    "ReturnValue",
+    "main",
+]
 
 
 class OpenAI(BaseSettings):
@@ -60,8 +68,12 @@ def cli_context(debug: bool = False) -> Iterator:
             exit(1)
 
 
+class ReturnValue(BaseModel):
+    config: CLIConfig
+
+
 @overload
-def main(debug: Literal[True]) -> CLIConfig:
+def main(debug: Literal[True]) -> ReturnValue:
     ...
 
 
@@ -70,13 +82,13 @@ def main(debug: Literal[False] = False) -> None:
     ...
 
 
-def main(debug: bool = False) -> CLIConfig | None:
+def main(debug: bool = False) -> ReturnValue | None:
     """CLI callable."""
     with cli_context(debug):
         config = defopt.run(CLIConfig)
         if debug:
             print(f"Loaded CLI config: {config}", file=stderr)
-    return config if debug else None
+    return ReturnValue(config=config) if debug else None
 
 
 if __name__ == "__main__":

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -21,7 +21,7 @@ def test_openai_api_key_cli_arg(key, url):
     args = ["--openai-api-key", key, "--url", url]
     result = run_cli(*args)
     expected = CLIConfig(openai_api_key=key, url=url)
-    assert result == expected
+    assert result.config == expected
 
 
 @mark.parametrize("key,url", [("e_key", "http://example.com")])
@@ -31,7 +31,7 @@ def test_openai_api_key_env_var(key, url):
     env_vars = {"OPENAI_API_KEY": key}
     result = run_cli(*args, **env_vars)
     expected = CLIConfig(openai_api_key=key, url=url)
-    assert result == expected
+    assert result.config == expected
 
 
 @mark.parametrize("arg_key,env_key,url", [("a_key", "e_key", "http://example.com")])
@@ -41,7 +41,7 @@ def test_openai_api_key_cli_arg_and_env_var(arg_key, env_key, url):
     env_vars = {"OPENAI_API_KEY": env_key}
     result = run_cli(*args, **env_vars)
     expected = CLIConfig(openai_api_key=arg_key, url=url)
-    assert result == expected
+    assert result.config == expected
 
 
 def test_missing_openai_api_key():


### PR DESCRIPTION
- refactor(cli): extract `main()` error handling into `cli_context()` ctx manager
  - fix(tests): update assertions to use the new `ReturnValue.config` attribute