### PR TITLE
test(scrape): rename and refactor tests

### DIFF
--- a/tests/helpers/data.py
+++ b/tests/helpers/data.py
@@ -1,0 +1,7 @@
+__all__ = ["target_css_mapping"]
+
+target_css_mapping = {
+    "animal": "body p i",
+    "clothing": "body p em",
+    "ghost": None,
+}

--- a/tests/scrape_test.py
+++ b/tests/scrape_test.py
@@ -6,40 +6,19 @@ from pytest_httpx import HTTPXMock
 import magic_scrape
 from magic_scrape.scrape import Selector, detect_selectors, get_first_page
 
+from .helpers.data import target_css_mapping
 from .helpers.extraction import mock_extract
 
 
-@mark.parametrize(
-    "target,expected",
-    [("animal", "body p i"), ("clothing", "body p em")],
-)
-def test_ai_extract_known_target_full_mock(target, expected, fake_page):
+@mark.parametrize("target, expected", target_css_mapping.items())
+def test_ai_extract(target, expected, fake_page):
     with patch("magic_scrape.scrape.ai_extract", new=mock_extract):
         result = magic_scrape.scrape.ai_extract(target=target, page=fake_page)
         assert result == expected
 
 
-@mark.parametrize(
-    "target,expected",
-    [("animal", "body p i"), ("clothing", "body p em")],
-)
-def test_ai_extract_known_target_page_mock(target, expected, fake_page, fake_config):
-    fake_config.targets = [target]
-    with patch("magic_scrape.scrape.get_first_page", return_value=fake_page):
-        with patch("magic_scrape.scrape.ai_extract", new=mock_extract):
-            result = detect_selectors(config=fake_config, debug=False, verbose=False)
-            assert result == [Selector(target=target, css_pattern=expected)]
-
-
-@mark.parametrize("target,expected", [("ghost", None)])
-def test_ai_extract_unknown_target_full_mock(target, expected, fake_page):
-    with patch("magic_scrape.scrape.ai_extract", new=mock_extract):
-        result = magic_scrape.scrape.ai_extract(target=target, page=fake_page)
-        assert result is expected
-
-
-@mark.parametrize("target,expected", [("ghost", None)])
-def test_ai_extract_unknown_target_page_mock(target, expected, fake_page, fake_config):
+@mark.parametrize("target, expected", target_css_mapping.items())
+def test_detect_selectors(target, expected, fake_page, fake_config):
     fake_config.targets = [target]
     with patch("magic_scrape.scrape.get_first_page", return_value=fake_page):
         with patch("magic_scrape.scrape.ai_extract", new=mock_extract):


### PR DESCRIPTION
- Rename tests to match the highest level function being tested
- Use `target_css_mapping` from `helpers.data`
- Parametrize with `target_css_mapping` dictionary, for readability and DRYness.