### PR TITLE
feat: Structured extraction of CSS targets

### DIFF
--- a/src/magic_scrape/extract.py
+++ b/src/magic_scrape/extract.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+__all__ = ["ai_extract"]
+
+
+def ai_extract(target: str, page: str) -> str | None:
+    """Extract a CSS selector for the given target from the page URL content"""
+    raise NotImplementedError("Insert OpenAI extraction magic here")

--- a/src/magic_scrape/scrape.py
+++ b/src/magic_scrape/scrape.py
@@ -5,9 +5,10 @@ from pydantic import BaseModel, Field
 from pydantic_xml import BaseXmlModel, element
 
 from .config import CLIConfig
+from .extract import ai_extract
 from .log import err
 
-__all__ = ["Selector", "ai_extract", "get_first_page", "detect_selectors"]
+__all__ = ["Selector", "get_first_page", "detect_selectors"]
 
 NSMAP = {"": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 
@@ -15,11 +16,6 @@ NSMAP = {"": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 class Selector(BaseModel):
     target: str = Field(..., description="Part of the web page to be extracted")
     css_pattern: str | None = Field(..., description="CSS pattern for the target")
-
-
-def ai_extract(target: str, page: str) -> str | None:
-    """Extract a CSS selector for the given target from the page URL content"""
-    raise NotImplementedError("Insert OpenAI extraction magic here")
 
 
 class Url(BaseXmlModel, tag="url", nsmap=NSMAP):  # type: ignore[call-arg]

--- a/tests/scrape_test.py
+++ b/tests/scrape_test.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from pytest import mark
 from pytest_httpx import HTTPXMock
 
-import magic_scrape
+from magic_scrape import scrape
 from magic_scrape.scrape import Selector, detect_selectors, get_first_page
 
 from .helpers.data import target_css_mapping
@@ -12,8 +12,9 @@ from .helpers.extraction import mock_extract
 
 @mark.parametrize("target, expected", target_css_mapping.items())
 def test_ai_extract(target, expected, fake_page):
+    """Patch the extract.ai_extract function after it's impored into scrape"""
     with patch("magic_scrape.scrape.ai_extract", new=mock_extract):
-        result = magic_scrape.scrape.ai_extract(target=target, page=fake_page)
+        result = scrape.ai_extract(target=target, page=fake_page)
         assert result == expected
 
 


### PR DESCRIPTION
- refactor(extract): moved the `ai_extract` function out of the scrape module
  - Patch the `extract.ai_extract` function after it was imported into `scrape` when mock testing
  - Don't import entire package in tests when not necessary

(Rest still to do)